### PR TITLE
Mindre rettelser til typehint

### DIFF
--- a/src/sgis/geopandas_tools/bounds.py
+++ b/src/sgis/geopandas_tools/bounds.py
@@ -1,5 +1,6 @@
 import numbers
-from typing import Any, Callable, Iterable
+from typing import Any
+from collections.abc import Callable, Collection, Mapping
 
 import geopandas as gpd
 import numpy as np
@@ -439,7 +440,7 @@ def bounds_to_points(
 
 
 def to_bbox(
-    obj: GeoDataFrame | GeoSeries | Geometry | Iterable | dict,
+    obj: GeoDataFrame | GeoSeries | Geometry | Collection | Mapping,
 ) -> tuple[float, float, float, float]:
     """Returns 4-length tuple of bounds if possible, else raises ValueError.
 

--- a/src/sgis/geopandas_tools/duplicates.py
+++ b/src/sgis/geopandas_tools/duplicates.py
@@ -1,4 +1,4 @@
-from typing import Callable, Iterable
+from collections.abc import Iterable
 
 import networkx as nx
 import pandas as pd

--- a/src/sgis/geopandas_tools/general.py
+++ b/src/sgis/geopandas_tools/general.py
@@ -1,6 +1,7 @@
 import numbers
 import warnings
-from typing import Any, Iterable
+from typing import Any
+from collections.abc import Iterable, Hashable
 
 import numpy as np
 import pandas as pd
@@ -22,7 +23,7 @@ from .conversion import to_gdf
 from .geometry_types import get_geom_type, make_all_singlepart, to_single_geom_type
 
 
-def get_common_crs(iterable: Iterable[Any], strict: bool = False) -> pyproj.CRS | None:
+def get_common_crs(iterable: Iterable[Hashable], strict: bool = False) -> pyproj.CRS | None:
     """Returns the common not-None crs or raises a ValueError if more than one.
 
     Args:

--- a/src/sgis/helpers.py
+++ b/src/sgis/helpers.py
@@ -3,7 +3,7 @@ import glob
 import inspect
 import os
 import warnings
-from typing import Callable
+from collections.abc import Callable
 
 import numpy as np
 from geopandas import GeoDataFrame

--- a/src/sgis/io/write_municipality_data.py
+++ b/src/sgis/io/write_municipality_data.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Callable
+from collections.abc import Callable
 
 import pandas as pd
 from dapla import write_pandas

--- a/src/sgis/maps/explore.py
+++ b/src/sgis/maps/explore.py
@@ -7,7 +7,7 @@ import os
 import warnings
 from numbers import Number
 from statistics import mean
-from typing import Iterable
+from collections.abc import Iterable
 
 import branca as bc
 import folium

--- a/src/sgis/parallel/parallel.py
+++ b/src/sgis/parallel/parallel.py
@@ -2,8 +2,8 @@ import functools
 import itertools
 import multiprocessing
 from pathlib import Path
-from typing import Any, Callable, Iterable, Sized
-
+from typing import Any
+from collections.abc import Collection, Callable, Iterable
 
 try:
     import dapla as dp
@@ -73,7 +73,7 @@ class Parallel:
     def map(
         self,
         func: Callable,
-        iterable: Iterable,
+        iterable: Collection,
         kwargs: dict | None = None,
     ) -> list[Any]:
         """Run functions in parallel with items of an iterable as first arguemnt.
@@ -151,7 +151,7 @@ class Parallel:
     def starmap(
         self,
         func: Callable,
-        iterable: Iterable[Iterable[Any]],
+        iterable: Collection[Iterable[Any]],
         kwargs: dict | None = None,
     ) -> list[Any]:
         """Run functions in parallel where items of the iterable are unpacked.

--- a/src/sgis/raster/raster.py
+++ b/src/sgis/raster/raster.py
@@ -5,7 +5,7 @@ import warnings
 from copy import copy, deepcopy
 from json import loads
 from pathlib import Path
-from typing import Callable
+from collections.abc import Callable
 
 import geopandas as gpd
 import matplotlib.pyplot as plt

--- a/src/sgis/raster/zonal.py
+++ b/src/sgis/raster/zonal.py
@@ -1,4 +1,4 @@
-from typing import Callable
+from collections.abc import Callable
 
 import geopandas as gpd
 import numpy as np


### PR DESCRIPTION
Her kommer noen små rettelser til typehintene. 
`Iterable` er byttet ut med `Collection` på to steder, der det er forventet at objektene har en størrelse, se #161, `Any` er byttet ut med `Hashable` på et sted der objektene settes inn i et `set`, og `dict` er byttet ut med den mer generelle `Mapping`.
I tillegg er alle alias fra `typing` byttet ut med import direkte fra `collections.abc`.