### PR TITLE
Lagt til bakgrunnskart fra Kartverket

### DIFF
--- a/src/sgis/maps/explore.py
+++ b/src/sgis/maps/explore.py
@@ -26,6 +26,7 @@ from ..geopandas_tools.general import clean_geoms, make_all_singlepart
 from ..geopandas_tools.geometry_types import get_geom_type, to_single_geom_type
 from ..helpers import unit_is_degrees
 from .httpserver import run_html_server
+from .tilesources import kartverket, xyz
 from .map import Map
 
 
@@ -366,7 +367,6 @@ class Explore(Map):
             self._categories_colors_dict.keys(),
             self._categories_colors_dict.values(),
         )
-        folium.TileLayer("stamentoner", max_zoom=self.max_zoom).add_to(self.map)
         folium.TileLayer("cartodbdark_matter", max_zoom=self.max_zoom).add_to(self.map)
         self.map.add_child(folium.LayerControl())
 
@@ -428,7 +428,6 @@ class Explore(Map):
             self.map.add_child(f)
 
         self.map.add_child(colorbar)
-        folium.TileLayer("stamentoner").add_to(self.map)
         folium.TileLayer("cartodbdark_matter").add_to(self.map)
         self.map.add_child(folium.LayerControl())
 
@@ -456,7 +455,7 @@ class Explore(Map):
         self,
         bounds,
         attr=None,
-        tiles="OpenStreetMap",
+        tiles=kartverket.norges_grunnkart,
         width="100%",
         height="100%",
         control_scale=True,
@@ -497,7 +496,7 @@ class Explore(Map):
         # match provider name string to xyzservices.TileProvider
         if isinstance(tiles, str):
             try:
-                tiles = xyzservices.providers.query_name(tiles)
+                tiles = xyz.query_name(tiles)
             except ValueError:
                 pass
 
@@ -505,7 +504,6 @@ class Explore(Map):
             attr = attr if attr else tiles.html_attribution
             map_kwds["min_zoom"] = tiles.get("min_zoom", 0)
             map_kwds["max_zoom"] = tiles.get("max_zoom", 30)
-            tiles = tiles.build_url(scale_factor="{r}")
 
         m = folium.Map(
             location=location,

--- a/src/sgis/maps/tilesources.py
+++ b/src/sgis/maps/tilesources.py
@@ -1,0 +1,61 @@
+from xyzservices import TileProvider, Bunch, providers
+
+kartverket = Bunch(
+    norgeskart=TileProvider(
+        name="Norgeskart",
+        url="https://opencache.statkart.no/gatekeeper/gk/gk.open_gmaps?layers=norgeskart_bakgrunn&zoom={z}&x={x}&y={y}",
+        attribution="© Kartverket",
+        html_attribution='&copy; <a href="https://kartverket.no">Kartverket</a>',
+    ),
+
+    bakgrunnskart_forenklet=TileProvider(
+        name="Norgeskart forenklet",
+        url="https://opencache.statkart.no/gatekeeper/gk/gk.open_gmaps?layers=bakgrunnskart_forenklet&zoom={z}&x={x}&y={y}",
+        attribution="© Kartverket",
+        html_attribution='&copy; <a href="https://kartverket.no">Kartverket</a>',
+    ),
+
+    norges_grunnkart=TileProvider(
+        name="Norges grunnkart",
+        url="https://opencache.statkart.no/gatekeeper/gk/gk.open_gmaps?layers=norges_grunnkart&zoom={z}&x={x}&y={y}",
+        attribution="© Kartverket",
+        html_attribution='&copy; <a href="https://kartverket.no">Kartverket</a>',
+    ),
+
+    norges_grunnkart_gråtone=TileProvider(
+        name="Norges grunnkart gråtone",
+        url="https://opencache.statkart.no/gatekeeper/gk/gk.open_gmaps?layers=norges_grunnkart_graatone&zoom={z}&x={x}&y={y}",
+        attribution="© Kartverket",
+        html_attribution='&copy; <a href="https://kartverket.no">Kartverket</a>',
+    ),
+
+    n50=TileProvider(
+        name="N5 til N50 kartdata",
+        url="https://opencache.statkart.no/gatekeeper/gk/gk.open_gmaps?layers=kartdata3&zoom={z}&x={x}&y={y}",
+        attribution="© Kartverket",
+        html_attribution='&copy; <a href="https://kartverket.no">Kartverket</a>',
+    ),
+
+    topogråtone=TileProvider(
+        name="Topografisk norgeskart gråtone",
+        url="https://opencache.statkart.no/gatekeeper/gk/gk.open_gmaps?layers=topo4graatone&zoom={z}&x={x}&y={y}",
+        attribution="© Kartverket",
+        html_attribution='&copy; <a href="https://kartverket.no">Kartverket</a>',
+    ),
+
+    toporaster=TileProvider(
+        name="Topografisk raster",
+        url="https://opencache.statkart.no/gatekeeper/gk/gk.open_gmaps?layers=toporaster4&zoom={z}&x={x}&y={y}",
+        attribution="© Kartverket",
+        html_attribution='&copy; <a href="https://kartverket.no">Kartverket</a>',
+    ),
+
+    norge_i_bilder=TileProvider(
+        name="Norge i bilder",
+        url="https://opencache.statkart.no/gatekeeper/gk/gk.open_nib_web_mercator_wmts_v2?SERVICE=WMTS&REQUEST=GetTile&VERSION=1.0.0&LAYER=Nibcache_web_mercator_v2&STYLE=default&FORMAT=image/jpgpng&tileMatrixSet=default028mm&tileMatrix={z}&tileRow={y}&tileCol={x}",
+        max_zoom=19,
+        attribution="© Geovekst",
+    ),
+)
+
+xyz = Bunch({"Kartverket": kartverket} | providers)


### PR DESCRIPTION
Her er noen kart fra Kartverket, som kan brukes som bakgrunnskart.
Standard bakgrunnskart for sgis.explore er endret fra "Openstreetmap Carto" til "Norges grunnkart".  Openstreetmap Carto er et ganske fargesterkt kart, og egner seg derfor ikke så godt som bakgrunnskart.  "Stamen toner" er fjernet, siden det ikke lastet når jeg testet det nå.