### PR TITLE
Bytter bakgrunnskart fra Kartverket

### DIFF
--- a/src/sgis/maps/explore.py
+++ b/src/sgis/maps/explore.py
@@ -215,10 +215,10 @@ class Explore(Map):
 
     # class attribute that can be overridden locally
     tiles: ClassVar[tuple[str, ...]] = (
-        "OpenStreetMap",
-        "dark",
-        "norge_i_bilder",
         "grunnkart",
+        "norge_i_bilder",
+        "dark",
+        "OpenStreetMap",
     )
 
     def __init__(

--- a/src/sgis/maps/explore.py
+++ b/src/sgis/maps/explore.py
@@ -144,8 +144,8 @@ def to_tile(tile: str | xyzservices.TileProvider, max_zoom: int) -> folium.TileL
         "openstreetmap": folium.TileLayer(
             "OpenStreetMap", min_zoom=0, max_zoom=max_zoom
         ),
-        "grunnkart": kartverket.norges_grunnkart,
-        "gråtone": kartverket.norges_grunnkart_gråtone,
+        "grunnkart": kartverket.topo,
+        "gråtone": kartverket.topogråtone,
         "norge_i_bilder": kartverket.norge_i_bilder,
         "dark": xyz.CartoDB.DarkMatter,
         "voyager": xyz.CartoDB.Voyager,
@@ -214,11 +214,11 @@ class Explore(Map):
     """Class for displaying and saving html maps of multiple GeoDataFrames."""
 
     # class attribute that can be overridden locally
-    tiles: ClassVar[tuple[str]] = (
+    tiles: ClassVar[tuple[str, ...]] = (
         "OpenStreetMap",
         "dark",
         "norge_i_bilder",
-        # "grunnkart",
+        "grunnkart",
     )
 
     def __init__(

--- a/src/sgis/maps/tilesources.py
+++ b/src/sgis/maps/tilesources.py
@@ -3,45 +3,27 @@ from xyzservices import TileProvider
 from xyzservices import providers
 
 kartverket = Bunch(
-    norgeskart=TileProvider(
-        name="Norgeskart",
-        url="https://opencache.statkart.no/gatekeeper/gk/gk.open_gmaps?layers=norgeskart_bakgrunn&zoom={z}&x={x}&y={y}",
-        attribution="© Kartverket",
-        html_attribution='&copy; <a href="https://kartverket.no">Kartverket</a>',
-    ),
-    bakgrunnskart_forenklet=TileProvider(
-        name="Norgeskart forenklet",
-        url="https://opencache.statkart.no/gatekeeper/gk/gk.open_gmaps?layers=bakgrunnskart_forenklet&zoom={z}&x={x}&y={y}",
-        attribution="© Kartverket",
-        html_attribution='&copy; <a href="https://kartverket.no">Kartverket</a>',
-    ),
-    norges_grunnkart=TileProvider(
-        name="Norges grunnkart",
-        url="https://opencache.statkart.no/gatekeeper/gk/gk.open_gmaps?layers=norges_grunnkart&zoom={z}&x={x}&y={y}",
-        attribution="© Kartverket",
-        html_attribution='&copy; <a href="https://kartverket.no">Kartverket</a>',
-    ),
-    norges_grunnkart_gråtone=TileProvider(
-        name="Norges grunnkart gråtone",
-        url="https://opencache.statkart.no/gatekeeper/gk/gk.open_gmaps?layers=norges_grunnkart_graatone&zoom={z}&x={x}&y={y}",
-        attribution="© Kartverket",
-        html_attribution='&copy; <a href="https://kartverket.no">Kartverket</a>',
-    ),
-    n50=TileProvider(
-        name="N5 til N50 kartdata",
-        url="https://opencache.statkart.no/gatekeeper/gk/gk.open_gmaps?layers=kartdata3&zoom={z}&x={x}&y={y}",
+    topo=TileProvider(
+        name="Topografisk norgeskart",
+        url="https://cache.kartverket.no/v1/wmts/1.0.0/topo/default/webmercator/{z}/{y}/{x}.png",
         attribution="© Kartverket",
         html_attribution='&copy; <a href="https://kartverket.no">Kartverket</a>',
     ),
     topogråtone=TileProvider(
         name="Topografisk norgeskart gråtone",
-        url="https://opencache.statkart.no/gatekeeper/gk/gk.open_gmaps?layers=topo4graatone&zoom={z}&x={x}&y={y}",
+        url="https://cache.kartverket.no/v1/wmts/1.0.0/topograatone/default/webmercator/{z}/{y}/{x}.png",
         attribution="© Kartverket",
         html_attribution='&copy; <a href="https://kartverket.no">Kartverket</a>',
     ),
     toporaster=TileProvider(
         name="Topografisk raster",
-        url="https://opencache.statkart.no/gatekeeper/gk/gk.open_gmaps?layers=toporaster4&zoom={z}&x={x}&y={y}",
+        url="https://cache.kartverket.no/v1/wmts/1.0.0/toporaster/default/webmercator/{z}/{y}/{x}.png",
+        attribution="© Kartverket",
+        html_attribution='&copy; <a href="https://kartverket.no">Kartverket</a>',
+    ),
+    sjøkart=TileProvider(
+        name="Sjøkart",
+        url="https://cache.kartverket.no/v1/wmts/1.0.0/sjokartraster/default/webmercator/{z}/{y}/{x}.png",
         attribution="© Kartverket",
         html_attribution='&copy; <a href="https://kartverket.no">Kartverket</a>',
     ),


### PR DESCRIPTION
Kartverket har stengt ned de åpne WMTS-tjenestene under https://opencache.statkart.no i år.

[Store endringer i Kartverkets tjenestetilbud for karttjenester
](https://www.geonorge.no/aktuelt/Se-siste-nyheter/store-endringer-i-kartverkets-cachetjenester/) [Treghet på karttjenesten opencache.statkart.no](https://www.kartverket.no/om-kartverket/nyheter/alle/2024/juli/treghet-pa-opencache.statkart.no)

Erstatnings-tjenesten https://cache.kartverket.no/v1/wmts/1.0.0/ tilbyr dessverre færre alternativer. Det forenklet bakgrunnskartet er tatt vekk.

[Liste over alternativer](https://status.geonorge.no/cache.html)